### PR TITLE
Font Style fix and default setting for size

### DIFF
--- a/Modules/BuildUI.py
+++ b/Modules/BuildUI.py
@@ -125,10 +125,14 @@ def build_toolbar(editor):
 
 
     font_family = QFontComboBox()
+    default_font = font_family.currentFont().family()
+    print(f"default font is {default_font}")
     font_family.currentFontChanged.connect(lambda: editorSignalsInstance.widgetAttributeChanged.emit(ChangedWidgetAttribute.Font, font_family.currentFont().family()))
 
     font_size = QComboBox()
     font_size.addItems([str(fs) for fs in FONT_SIZES])
+    default_font_size_index = 8 #default text size is 18
+    font_size.setCurrentIndex(default_font_size_index)
     font_size.currentIndexChanged.connect(lambda: editorSignalsInstance.widgetAttributeChanged.emit(ChangedWidgetAttribute.FontSize, int(font_size.currentText())))
 
     #current issues: 

--- a/Widgets/Textbox.py
+++ b/Widgets/Textbox.py
@@ -242,7 +242,7 @@ class TextboxWidget(QTextEdit):
     def changeFontEvent(self, font_style):
         cursor = self.textCursor()
         current_format = cursor.charFormat()
-        current_format.setFont(font_style)
+        current_format.setFontFamily(font_style)
 
         cursor.setCharFormat(current_format)
 


### PR DESCRIPTION
Font Style no longer changes size when changing it through toolbar Font Size on toolbar is now default to 18 to match default size in editor